### PR TITLE
ENYO-2390: remove unneeded preventDefault call that causes reorders to f...

### DIFF
--- a/list/source/List.js
+++ b/list/source/List.js
@@ -296,7 +296,6 @@ enyo.kind({
 		if (inEvent.holdTime >= this.reorderHoldTimeMS) {
 			// determine if we should handle the hold event
 			if (this.shouldStartReordering(inSender, inEvent)) {
-				inEvent.preventDefault();
 				this.startReordering(inEvent);
 				return false;
 			}


### PR DESCRIPTION
...ail in Chrome with exception due to delayed holdpulse event

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
