### PR TITLE
Allow sliding panel acceleration to be 'auto'

### DIFF
--- a/panels/source/arrangers/Arranger.js
+++ b/panels/source/arrangers/Arranger.js
@@ -141,7 +141,7 @@ enyo.kind({
 		this.c$ = [].concat(this.container.getPanels());
 		this.controlsIndex = 0;
 		for (var i=0, c$=this.container.getPanels(), c; (c=c$[i]); i++) {
-			enyo.dom.accelerate(c, this.accelerated && !c.preventAccelerate);
+			enyo.dom.accelerate(c, !c.preventAccelerate && this.accelerated);
 			if (enyo.platform.safari) {
 				// On Safari-desktop, sometimes having the panel's direct child set to accelerate isn't sufficient
 				// this is most often the case with Lists contained inside another control, inside a Panels


### PR DESCRIPTION
Auto acceleration checks enyo.dom.canAccelerate() before setting translateZ. Without this check, collapsing panels do not work on Opera.
