### PR TITLE
ENYO-2987: Change enyo.super to enyo.inherit to avoid clash with ES3 res...

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,6 +4,7 @@
         "$L": true,
         "onyx": true
     },
+    "es3": true,
     "evil": false,
     "regexdash": true,
     "browser": true,

--- a/flex/source/mixin.LayoutInvalidator.js
+++ b/flex/source/mixin.LayoutInvalidator.js
@@ -18,7 +18,7 @@ enyo.LayoutInvalidator = {
 		}
 	},
 
-	rendered: enyo.super(function (sup) {
+	rendered: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.invalidateLayout();
@@ -30,14 +30,14 @@ enyo.LayoutInvalidator = {
 		this.bubble('onInvalidateLayout', {}, this);
 	},
 
-	contentChanged: enyo.super(function (sup) {
+	contentChanged: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.invalidateLayout();
 		};
 	}),
 
-	classesChanged: enyo.super(function (sup) {
+	classesChanged: enyo.inherit(function (sup) {
 		return function() {
 			sup.apply(this, arguments);
 			this.invalidateLayout();


### PR DESCRIPTION
...erved work
- Restore .jshintrc to check es3: true now that we're not using super.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
