### PR TITLE
GF-13581 defect fix

### DIFF
--- a/list/source/List.css
+++ b/list/source/List.css
@@ -5,7 +5,6 @@
 .enyo-list-port {
 	overflow: hidden;
 	position: relative;
-	height: 1000000px;
 }
 
 .enyo-list-holdingarea {
@@ -16,6 +15,13 @@
 
 .enyo-list-port.horizontal {
 	white-space: nowrap;
+	width:  1000000px;
+	height: 1000000px;
+}
+
+.enyo-list-port.vertical {
+	white-space: nowrap;
+	height: 1000000px;
 }
 
 .enyo-list-page {

--- a/list/source/List.js
+++ b/list/source/List.js
@@ -197,6 +197,7 @@ enyo.kind({
 		this.getStrategy().translateOptimized = true;
 		this.pageBound = this.orientV ? "top" : "left";
 		this.$.port.addRemoveClass("horizontal",!this.orientV);
+		this.$.port.addRemoveClass("vertical",this.orientV);
 		this.$.page0.addRemoveClass("vertical",this.orientV);
 		this.$.page1.addRemoveClass("vertical",this.orientV);
 		this.bottomUpChanged();


### PR DESCRIPTION
As per the defect the horizontal scrollbar was not appear at the first
launch.
This is because the initial scroll width and container width difference
is zero,
because, initially scroll width is being set to the client area of the
scroller rather than the full width of the scroller element.
Default Scroll Height has been set for Vertical to solve this issue for
vertical list for first launch.
So have added initial default width and height for horizontal as it was
there for vertical.

Enyo-DCO-1.1-Signed-off-by: Ashwini R ashwini13.r@lge.com
