### PR TITLE
GF-36974: Clear old translation values on controls with preventTransform

### DIFF
--- a/panels/source/arrangers/Arranger.js
+++ b/panels/source/arrangers/Arranger.js
@@ -211,6 +211,11 @@ enyo.kind({
 					t = enyo.isString(t) ? t : t && (t + unit);
 					enyo.dom.transform(inControl, {translateX: l || null, translateY: t || null});
 				} else {
+					// If a previously positioned control has subsequently been marked with
+					// preventTransform, we need to clear out any old translation values.
+					if (enyo.dom.canTransform() && inControl.preventTransform) {
+						enyo.dom.transform(inControl, {translateX: null, translateY: null});
+					}
 					inControl.setBounds(inBounds, inUnit);
 				}
 			}


### PR DESCRIPTION
If a previously positioned Control has subsequently been marked with preventTransform, we need to clear out any old translation values before positioning with top/left.

This situation arose when adding "disableAcceleration" functionality to an internal panel library..

Enyo-DCO-1.1-Signed-Off-By: Gray Norton gray.norton@lge.com
