### PR TITLE
GF-9854-ListPulldownSampleUpdated

### DIFF
--- a/list/samples/ListPulldownSample.js
+++ b/list/samples/ListPulldownSample.js
@@ -54,8 +54,22 @@ enyo.kind({
 			text: inSearchText,
 			sort: 'date-posted-desc',
 			extras: 'url_m'
-		};
-		new enyo.JsonpRequest({url: "http://api.flickr.com/services/rest/", callbackName: "jsoncallback"}).response(this, "processSearchResults").go(params);
+		}, url = "http://api.flickr.com/services/rest/";
+		if (window.location.protocol === "ms-appx:") {
+			params.nojsoncallback = 1;
+			// Use ajax for platforms with no jsonp support (Windows 8)
+			new enyo.Ajax({url: url, handleAs: "text"})
+				.response(this, "processAjaxSearchResults")
+				.go(params);
+		} else {
+			new enyo.JsonpRequest({url: url, callbackName: "jsoncallback"})
+				.response(this, "processSearchResults")
+				.go(params);
+		}
+	},
+	processAjaxSearchResults: function(inRequest, inResponse) {
+		inResponse = JSON.parse(inResponse);
+		this.processSearchResults(inRequest, inResponse);
 	},
 	processSearchResults: function(inRequest, inResponse) {
 		this.results = inResponse.photos.photo;


### PR DESCRIPTION
The pulldown list is not appearing in the sample.
The Sample was using twitter open API earlier, which is closed now.
So the API is replaced with the flickr API that's been used in other
list samples.

Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P rajyavardhan.p@lge.com
