### PR TITLE
GF-36974: Disable translation (and fall back to absolute positioning) for a given ...

### DIFF
--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -174,13 +174,13 @@ enyo.kind({
 			if (!inProps.isChrome) {
 				inProps.handlers = {
 					onDisableTranslation: "disableTranslation"
-				}
+				};
 				inProps.disableTranslation = function() {
 					this.preventTransform = true;
-				}
+				};
 			}
 			sup.apply(this, arguments);
-		}
+		};
 	}),
 
 	//* @public


### PR DESCRIPTION
...panel when requested by a component within the panel, via the "onDisableTranslation" event.

Currently needed to work around video rendering issues on webOS, this mechanism will most likely be removed when the root causes of those issues are addressed. Note that the mechanism is currently "one-way." If we end up keeping it for the longer term, we should probably extend it to allow translation to be re-enabled as needed.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton gray.norton@lge.com
