### PR TITLE
GF-9908 ImageView Pin Zoom Defect Fixed

### DIFF
--- a/imageview/source/ImageView.js
+++ b/imageview/source/ImageView.js
@@ -24,6 +24,18 @@ enyo.kind({
 	subKindComponents: [
 		{kind:"Image", ondown: "down", style: "vertical-align: text-top;"}
 	],
+	handlers: {
+		onPinTap : "pinZoom"
+	},
+	pinZoom: function(inSender, inEvent) {
+		if(enyo.platform.ie==8) {
+			this.doubleClick(inSender, inEvent);
+		}
+		else {
+			this.smartZoom(inSender, inEvent);
+		}
+		return true;
+	},
 	create: enyo.inherit(function(sup) {
 		return function() {
 			// move components (most likely imageViewPins) to unscaledComponents

--- a/imageview/source/ImageViewPin.js
+++ b/imageview/source/ImageViewPin.js
@@ -48,7 +48,11 @@ enyo.kind({
 	//* @protected
 	style: "position:absolute;z-index:1000;width:0px;height:0px;",
 	handlers: {
-		onPositionPin: "reAnchor"
+		onPositionPin: "reAnchor",
+		ondblclick: "bubbleZoom"
+	},
+	bubbleZoom: function(inSender, inEvent) {
+		this.bubble("onPinTap", inEvent);
 	},
 	create: enyo.inherit(function(sup) {
 		return function() {


### PR DESCRIPTION
Issue: When double clicking the yellow or red spot of image, image does
not be enlarged.
Fixes:
Added doubleClick handler to ImageViewPin.js which bubbles up event to
its parent.
Added handler to ImageView.js to handle bubble event from pin and
enlarge the image.

Enyo-DCO-1.1-Signed-off-by: Anugrah Saxena anugrah.saxena@lge.com
