### PR TITLE
GF-8538-defect fixed

### DIFF
--- a/list/source/GridList.js
+++ b/list/source/GridList.js
@@ -54,7 +54,6 @@ enyo.kind(
         name: "enyo.GridList",
         kind: "enyo.List",
         classes: "enyo-gridlist",
-        noDefer: true,
         published: {
             /**
                 Set to true if you want all items to be of same size with fluid

--- a/list/source/List.js
+++ b/list/source/List.js
@@ -25,7 +25,6 @@ enyo.kind({
 	name: "enyo.List",
 	kind: "Scroller",
 	classes: "enyo-list",
-	noDefer: true,
 	published: {
 		/**
 			The number of rows contained in the list. Note that as the amount of


### PR DESCRIPTION
Deferred kind scheme breaks Spotlight decorator lookup.
According to the latest changes in Spotlight, it is no longer required
to use noDefer property in enyo.List and enyo.GridList.

Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P rajyavardhan.p@lge.com
