### PR TITLE
ENYO-1836: Update layout.design with missing components and components to ignore in the palette's designer of Ares

### DIFF
--- a/layout.design
+++ b/layout.design
@@ -1,11 +1,37 @@
 {
     "palette": [
         {
+            "name": "layout",
+            "items": [
+                {
+                    "name": "enyo.Node",
+                    "description": "A tree node",
+                    "config": {
+                        "kind": "enyo.Node"
+                    }
+                },
+                {
+                    "name": "enyo.Panels",
+                    "description": "Selectable sub-view",
+                    "config": {
+                        "kind": "enyo.Panels",
+                        "classes": "enyo-fit"
+                    }
+                },
+                {
+                    "name": "enyo.Slideable",
+                    "description": "Slideable sub-view",
+                    "config": {
+                        "kind": "enyo.Slideable"
+                    }
+                }
+            ]
+        },
+        {
             "name": "layout-fittable",
             "items": [
                 {
                     "name": "enyo.FittableRows",
-                    "kind": "enyo.FittableRows",
                     "description": "Vertical stacked layout",
                     "config": {
                         "kind": "enyo.FittableRows"
@@ -13,7 +39,6 @@
                 },
                 {
                     "name": "enyo.FittableColumns",
-                    "kind": "enyo.FittableColumns",
                     "description": "Horizontal stacked layout",
                     "config": {
                         "kind": "enyo.FittableColumns"
@@ -26,7 +51,6 @@
             "items": [
                 {
                     "name": "enyo.ImageCarousel",
-                    "kind": "enyo.ImageCarousel",
                     "description": "A carousel of images",
                     "config": {
                         "kind": "enyo.ImageCarousel"
@@ -34,7 +58,6 @@
                 },
                 {
                     "name": "enyo.ImageView",
-                    "kind": "enyo.ImageView",
                     "description": "A scalable Image View",
                     "config": {
                         "kind": "enyo.ImageView"
@@ -42,7 +65,6 @@
                 },
                 {
                     "name": "enyo.ImageViewPin",
-                    "kind": "enyo.ImageViewPin",
                     "description": "An unscaled item inside an ImageView",
                     "config": {
                         "kind": "enyo.ImageViewPin"
@@ -55,7 +77,6 @@
             "items": [
                 {
                     "name": "enyo.AroundList",
-                    "kind": "enyo.AroundList",
                     "description": "List with elements above the list",
                     "config": {
                         "kind": "enyo.AroundList",
@@ -66,7 +87,6 @@
                 },
                 {
                     "name": "enyo.List",
-                    "kind": "enyo.List",
                     "description": "Infinite scrolling list",
                     "config": {
                         "kind": "enyo.List",
@@ -78,7 +98,6 @@
                 },
                 {
                     "name": "enyo.PulldownList",
-                    "kind": "enyo.PulldownList",
                     "description": "List with pull-to-refresh",
                     "config": {
                         "kind": "enyo.PulldownList",
@@ -88,115 +107,31 @@
                     }
                 }
             ]
-        },
+        }
+    ],
+    "inspector": [
         {
-            "name": "layout-slideable",
-            "items": [
-                {
-                    "name": "enyo.Slideable",
-                    "kind": "enyo.Slideable",
-                    "description": "Slideable sub-view",
-                    "config": {
-                        "kind": "enyo.Slideable"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "layout-tree",
-            "items": [
-                {
-                    "name": "enyo.Node",
-                    "kind": "enyo.Node",
-                    "description": "A tree node",
-                    "config": {
-                        "kind": "enyo.Node"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "ignore",
-            "items": [
-                {
-                    "name": "enyo.CardArranger",
-                    "kind": "enyo.Panels",
-                    "description": "Selectable sub-view",
-                    "config": {
-                        "kind": "enyo.Panels",
-                        "arrangerKind": "CardArranger",
-                        "classes": "enyo-fit"
-                    }
-                },
-                {
-                    "name": "enyo.CardSlideInArranger",
-                    "kind": "enyo.Panels",
-                    "description": "Selectable sub-view",
-                    "config": {
-                        "kind": "enyo.Panels",
-                        "arrangerKind": "CardSlideInArranger"
-                    }
-                },
-                {
-                    "name": "enyo.CarouselArranger",
-                    "kind": "enyo.Panels",
-                    "description": "Selectable sub-view",
-                    "config": {
-                        "kind": "enyo.Panels",
-                        "arrangerKind": "CarouselArranger"
-                    }
-                },
-                {
-                    "name": "enyo.CollapsingArranger",
-                    "kind": "enyo.Panels",
-                    "description": "Selectable sub-view",
-                    "config": {
-                        "kind": "enyo.Panels",
-                        "arrangerKind": "CollapsingArranger",
-                        "components": [
-                            {
-                                "content": "Placeholder"
-                            }
+            "type": "kind",
+            "name": "enyo.Panels",
+            "properties": {
+                "arrangerKind": {
+                    "filterLevel": "useful",
+                    "inputKind": {
+                        "kind": "Inspector.Config.Select",
+                        "values": [
+                            "CardArranger",
+                            "CardSlideInArranger",
+                            "CarouselArranger",
+                            "CollapsingArranger",
+                            "DockRightArranger",
+                            "GridArranger",
+                            "LeftRightArranger",
+                            "SpiralArranger",
+                            "TopBottomArranger"
                         ]
                     }
-                },
-                {
-                    "name": "enyo.DockRightArranger",
-                    "kind": "enyo.Panels",
-                    "description": "Selectable sub-view",
-                    "config": {
-                        "kind": "enyo.Panels",
-                        "arrangerKind": "DockRightArranger"
-                    }
-                },
-                {
-                    "name": "enyo.GridArranger",
-                    "kind": "enyo.Panels",
-                    "description": "Selectable sub-view",
-                    "config": {
-                        "kind": "enyo.Panels",
-                        "arrangerKind": "GridArranger"
-                    }
-                },
-                {
-                    "name": "enyo.LeftRightArranger",
-                    "kind": "enyo.Panels",
-                    "description": "Selectable sub-view",
-                    "config": {
-                        "kind": "enyo.Panels",
-                        "arrangerKind": "LeftRightArranger"
-                    }
-                },
-                {
-                    "name": "enyo.UpDownArranger",
-                    "kind": "enyo.Panels",
-                    "description": "Selectable sub-view",
-                    "config": {
-                        "kind": "enyo.Panels",
-                        "arrangerKind": "UpDownArranger"
-                    }
                 }
-            ]
+            }
         }
     ]
 }


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-1836

Update layout.design with missing components and components to ignore in the designer's palette of Ares Lighten components description, management

Must be reviewed (first) by @yves-del-medico and is related to other PRs:
* https://github.com/enyojs/ares-project/pull/632
- https://github.com/enyojs/enyo/pull/523
- https://github.com/enyojs/onyx/pull/183

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
