### PR TITLE
GF-36953:Contextual Popup is bleeds off the screen

### DIFF
--- a/contextual/source/ContextualLayout.js
+++ b/contextual/source/ContextualLayout.js
@@ -304,7 +304,7 @@ enyo.kind({
 			if ((activatorCenter >= (innerHeight/2 - 0.05 * innerHeight)) && (activatorCenter <= (innerHeight/2 + 0.05 * innerHeight))) {
 				this.applyPosition({top: this.offset.top + this.offset.height/2 - clientRect.height/2, bottom: "auto"});
 			} else if (this.offset.top + this.offset.height < innerHeight/2) { //the activator is in the top 1/2 of the screen
-				this.applyPosition({top: this.offset.top - this.offset.height, bottom: "auto"});
+				this.applyPosition({top: this.offset.top, bottom: "auto"});
 				this.container.addRemoveClass("high", true);
 			} else { //otherwise the popup will be positioned in the bottom 1/2 of the screen
 				this.applyPosition({top: this.offset.top - clientRect.height + this.offset.height*2, bottom: "auto"});


### PR DESCRIPTION
in regards http://jira2.lgsvl.com/browse/GF-36953

I've modified some calculation codes in ContextualLayout.js In this case, I think it doesn't need to minus activator's height. In order to fit popup's pointing nubs, I've modified moonstone too.(https://github.com/enyojs/moonstone/pull/715)

I think, popup pointing nubs's location should be calculated depends on activators and popup's size. Every case is  fixed for now in css.

Enyo-DCO-1.1-Signed-off-by: Goun Lee goun.lee@lge.com
