### PR TITLE
GF:42119-Translation disabled for any panel containing video

### DIFF
--- a/panels/source/arrangers/Arranger.js
+++ b/panels/source/arrangers/Arranger.js
@@ -162,7 +162,7 @@ enyo.kind({
 	flowArrangement: function() {
 		var a = this.container.arrangement;
 		if (a) {
-			for (var i=0, c$=this.container.getPanels(), c; (c=c$[i]); i++) {
+			for (var i=0, c$=this.container.getPanels(), c; (c=c$[i]) && (a[i]); i++) {
 				this.flowControl(c, a[i]);
 			}
 		}


### PR DESCRIPTION
in regards of http://jira2.lgsvl.com/browse/GF-42119

This issue mentioned in today's conference call by Kunmyon.
It is about "disableTranslation" event which is calling when Video component is rendered. In disableTranslation function() it calls layout.flowArrangement().  but in this case, newly added panel are not rendered yet. To prevent this issue, I've added a condition to check whether arrangement value exist or not. I've checked the result through attached sample in jira and It works fine..

Enyo-DCO-1.1-Signed-off-by: Goun Lee goun.lee@lge.com
