### PR TITLE
ENYO-3595: Fixed owner for unscaled components of PanZoomView.

### DIFF
--- a/imageview/source/PanZoomView.js
+++ b/imageview/source/PanZoomView.js
@@ -119,7 +119,8 @@ enyo.kind({
 			this.$.content.applyStyle("height", this.contentHeight + "px");
 
 			if(this.unscaledComponents){
-				this.createComponents(this.unscaledComponents);
+				var owner = this.hasOwnProperty("unscaledComponents") ? this.getInstanceOwner() : this;
+				this.createComponents(this.unscaledComponents, {owner: owner});
 			}
 
 			// Change controlParentName so PanZoomView instance components are created into viewport


### PR DESCRIPTION
## Issue

The PanZoomView change to ImageView pushes the declared components into a "non-scaled" component block that's created separately in the PanZoomView create(). However, they're created with the wrong owner, so they don't show up in the $ hash.
## Fix

If the "non-scaled" components are declared on the instance, set the owner to be the instance's owner, otherwise set the instance as the owner of inherited "non-scaled" components.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
