### PR TITLE
ENYO-3074: Removed calls to preventTap in dragfinish handlers

### DIFF
--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -305,7 +305,6 @@ enyo.kind({
 	dragfinish: function(inSender, inEvent) {
 		if (this.dragging) {
 			this.dragging = false;
-			inEvent.preventTap();
 			this.dragfinishTransition(inEvent);
 		}
 	},

--- a/slideable/source/Slideable.js
+++ b/slideable/source/Slideable.js
@@ -267,7 +267,6 @@ enyo.kind({
 		if (this.dragging) {
 			this.dragging = false;
 			this.completeDrag(inEvent);
-			inEvent.preventTap();
 			return this.preventDragPropagation;
 		}
 	},


### PR DESCRIPTION
## Issue

A `tap` event will be sent after a `dragfinish` event in a dragging context. The synthesized `dragfinish` no longer provides a `preventTap` method as part of this fix.
## Fix

Calls to `preventTap` have been removed from controls that handle `dragfinish`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
