### PR TITLE
ENYO-2505: Persistent item’s incomplete swipe action is completed on a subsequent swipe

### DIFF
--- a/list/source/List.js
+++ b/list/source/List.js
@@ -1521,7 +1521,10 @@ enyo.kind({
 				this.doSwipeComplete({index: this.swipeIndex, xDirection: this.swipeDirection});
 			}
 		} else {
-			this.persistentItemVisible = true;
+			// persistent item will only be visible if the swipe was completed
+			if (this.swipeComplete) {
+				this.persistentItemVisible = true;
+			}
 		}
 		this.swipeIndex = null;
 		this.swipeDirection = null;


### PR DESCRIPTION
## Issue

For persistent swipeable items, an incomplete swipe will be completed on a subsequent swipe (i.e. swipe and drag to scroll). This is caused by the `persistentItemVisible` flag being set to `true` regardless of the swipe completion status. 
## Fix

The `persistentItemVisible` flag is now only set if the swipe is complete. The choice to make a change here, as opposed to calling `setPersistSwipeableItem(false)` in the `backOutSwipe` method, is that this change is agnostic to how persistent items are implemented (currently `setPersistSwipeableItem(true)` needs to be called for each item via the `setupSwipeItem` handler). For example, if the implementation were to change such that the `persistSwipeableItem` flag on the `List` was not treated as temporary, then `setPersistSwipeableItem(false)` in `backOutSwipe` would eat this value.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
