### PR TITLE
Fixes encountered while working on demo app.

### DIFF
--- a/list/source/GridListImageItem.css
+++ b/list/source/GridListImageItem.css
@@ -11,8 +11,8 @@
 	display: block;
 	width: 100%;
 }
-.enyo-gridlist-imageitem .caption, .enyo-gridlist-imageitem .sub-caption {
-	text-align: center;
+.enyo-gridlist-imageitem >.caption,
+.enyo-gridlist-imageitem >.sub-caption {
 	font-size: 10pt;
 	z-index: 10;
 	padding-top: 10px;
@@ -22,7 +22,35 @@
 	overflow: hidden;
 	color: #fff;
 }
+.enyo-gridlist-imageitem.centered > .caption,
+.enyo-gridlist-imageitem.centered > .sub-caption {
+	text-align: center;
+}
 .enyo-gridlist-imageitem.disabled {
 	opacity: 0.4;
 	filter: alpha(opacity=40);
+}
+
+.enyo-gridlist-imageitem.sized-image.use-caption.use-subcaption {
+	padding-bottom: 50px;
+}
+.enyo-gridlist-imageitem.sized-image.use-caption,
+.enyo-gridlist-imageitem.sized-image.use-subcaption {
+	padding-bottom: 25px;
+}
+.enyo-gridlist-imageitem.sized-image > .image {
+	width: 100%;
+	height: 100%;
+}
+.enyo-gridlist-imageitem.sized-image.use-caption.use-subcaption > .caption {
+	position: absolute;
+	bottom: 22px;
+}
+.enyo-gridlist-imageitem.sized-image > .caption {
+	position: absolute;
+	bottom: 0;
+}
+.enyo-gridlist-imageitem.sized-image > .sub-caption {
+	position: absolute;
+	bottom: 0;
 }

--- a/list/source/GridListImageItem.js
+++ b/list/source/GridListImageItem.js
@@ -8,7 +8,7 @@ enyo.kind({
 	name: "enyo.GridListImageItem",
 	classes: "enyo-gridlist-imageitem",
 	components: [
-		{name: 'image', kind: 'enyo.Image'},
+		{name: "image", kind: "enyo.Image", classes:"image"},
 		{name: "caption", classes: "caption"},
 		{name: "subCaption", classes: "sub-caption"}
 	],
@@ -23,7 +23,33 @@ enyo.kind({
             Set to true to add the _selected_ class to the image tile; set to
             false to remove the _selected_ class
         */
-		selected: false
+		selected: false,
+		//* When true, caption & subCaption are centered; otherwise left-aligned
+		centered: true,
+		/** 
+			By default, the image width fits the width of the item, and the height
+			is sized naturally, based on the aspect ratio of the image.  Set this 
+			property to _constrain_ to letterbox the image in the available space,
+			or _cover_ to cover the available space with the image (cropping the
+			larger dimension).  Note, when _imageSizing_ is set, you must indicate
+			whether the caption and subCaption are used, based on the _useCaption_
+			and _useSubCaption_ flags, for proper sizing.
+		*/
+		imageSizing: "",
+		/**
+			When using an _imageSizing_ option, set to false if the caption space
+			should not be reserved.  Has no effect when imageSizing is default.
+		*/
+		useCaption: true,
+		/**
+			When using an _imageSizing_ option, set to false if the caption space
+			should not be reserved.  Has no effect when imageSizing is default.
+		*/
+		useSubCaption: true
+		/**
+			When using an _imageSizing_ option, set to false if the caption space
+			should not be reserved.  Has no effect when imageSizing is default.
+		*/
 	},
 	bindings: [
 		{from: ".source", to: ".$.image.src"},
@@ -36,6 +62,8 @@ enyo.kind({
 		return function() {
 			sup.apply(this, arguments);
 			this.selectedChanged();
+			this.imageSizingChanged();
+			this.centeredChanged();
 		};
 	}),
 	selectedChanged: function() {
@@ -43,5 +71,22 @@ enyo.kind({
 	},
 	disabledChanged: function() {
 		this.addRemoveClass("disabled", this.disabled);
+	},
+	imageSizingChanged: function() {
+		this.$.image.setSizing(this.imageSizing);
+		this.addRemoveClass("sized-image", !!this.imageSizing);
+		if (this.imageSizing) {
+			this.useCaptionChanged();
+			this.useSubCaptionChanged();
+		}
+	},
+	useCaptionChanged: function() {
+		this.addRemoveClass("use-caption", this.useCaption);
+	},
+	useSubCaptionChanged: function() {
+		this.addRemoveClass("use-subcaption", this.useSubCaption);
+	},
+	centeredChanged: function() {
+		this.addRemoveClass("centered", this.centered);
 	}
 });


### PR DESCRIPTION
Fixes encountered while working on demo app.
- enyo.GridListImageItem
  - Add `centered` property, to allow left-aligning captions by setting false
  - Add `imageSizing` property, facaded to enyo.Image in chrome
  - Add `useCaption` and `useSubCaption` for use with `imageSizing`, to control padding & absolute positioning of captions when `imageSizing` is used

Enyo-DCO-1.1-Signed-Off-By: Kevin Schaaf (kevin.schaaf@lge.com)
