### PR TITLE
Panels.setIndex() can wrap around, if `wrap` is enabled

### DIFF
--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -192,9 +192,8 @@ enyo.kind({
 		// override setIndex so that indexChanged is called
 		// whether this.index has actually changed or not. Also, do
 		// index clamping here.
-		var prev = this.get("index"),
-			next = this.clamp(inIndex);
-		this.index = next;
+		var prev = this.get("index");
+		this.index = this.clamp(inIndex);
 		this.notifyObservers("index", prev, inIndex);
 	},
 	/**


### PR DESCRIPTION
`enyo.Panels.setIndex()` can now respect values beyond the immediate scope of the current panel indexes, if `wrap: true` is present. Running `enyo.Panels.setIndex(-2)` will now set the index to the second-to-last panel on the `getPanels()` stack, if `wrap: true` is set. If not, it will simply set the index to 0 (zero), clamping, as it did previously.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
