### PR TITLE
isScreenNarrow support for Android 4.4 and above

### DIFF
--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -469,6 +469,8 @@ enyo.kind({
 					return (/iP(?:hone|od;(?: U;)? CPU) OS (\d+)/).test(ua);
 				case "android":
 					return (/Mobile/).test(ua) && (enyo.platform.android > 2 ? true : w <= 800);
+				case "androidChrome":
+					return (/Mobile/).test(ua);
 			}
 			return w <= 800;
 		},


### PR DESCRIPTION
Added specific support for Android Chrome & Android >= 4.4

Reference: https://developers.google.com/chrome/mobile/docs/user-agent
