### PR TITLE
In enyo.Panels, ensure that we report the right index value to observers

### DIFF
--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -192,9 +192,10 @@ enyo.kind({
 		// override setIndex so that indexChanged is called
 		// whether this.index has actually changed or not. Also, do
 		// index clamping here.
-		var prev = this.get("index");
-		this.index = this.clamp(inIndex);
-		this.notifyObservers("index", prev, inIndex);
+		var prevIndex = this.get("index"),
+			newIndex = this.clamp(inIndex);
+		this.index = newIndex;
+		this.notifyObservers("index", prevIndex, newIndex);
 	},
 	/**
 		Sets the active panel to the panel specified by the given index.


### PR DESCRIPTION
In enyo.Panels, we clamp the index value to ensure that it is being set to something legal. We also forcibly notify observers whenever index is set (regardless of whether the value has actually changed). In cases where the provided value has been clamped, we have been reporting the wrong (unclamped) value to observers. This change addresses this issue.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
