### PR TITLE
added better wrap support to LeftRightArranger

### DIFF
--- a/panels/source/arrangers/OtherArrangers.js
+++ b/panels/source/arrangers/OtherArrangers.js
@@ -117,7 +117,7 @@
 				var o = Math.floor(c$.length/2);
 				var wf = (s === 0 && f == (c$.length-1));
 				var wb = (s == (c$.length-1) && f === 0);
-		        var w = !wb ? wf ? wf : s > f : !wb;
+				var w = !wb && (wf || s > f);
 
 				for (var i=0, c; (c=c$[i]); i++) {
 					if (w){

--- a/panels/source/arrangers/OtherArrangers.js
+++ b/panels/source/arrangers/OtherArrangers.js
@@ -120,9 +120,10 @@
 				var f = this.container.toIndex;
 				var c$ = this.getOrderedControls(f);
 				var o = Math.floor(c$.length/2);
+				var w = !(s == (c$.length-1) && f == 0) || (s == 0 && f == (c$.length-1));
 
 				for (var i=0, c; (c=c$[i]); i++) {
-					if (s > f){
+					if (s > f & w){
 						if (i == (c$.length - o)){
 							c.applyStyle('z-index', 0);
 						} else {

--- a/panels/source/arrangers/OtherArrangers.js
+++ b/panels/source/arrangers/OtherArrangers.js
@@ -1,23 +1,18 @@
 (function (enyo, scope) {
-	/**
-	* {@link enyo.LeftRightArranger} is an {@link enyo.Arranger} that displays
-	* the active control and some of the previous and next controls. The active
-	* control is centered horizontally in the container, and the previous and next
-	* controls are laid out to the left and right, respectively.
-	*
-	* Transitions between arrangements are handled by sliding the new control in
-	* from the right and sliding the active control out to the left.
-	*
-	* For more information, see the documentation on
-	* [Arrangers]{@linkplain $dev-guide/building-apps/layout/arrangers.html} in the
-	* Enyo Developer Guide.
-	*
-	* @class  enyo.LeftRightArranger
-	* @extends enyo.Arranger
-	* @public
-	*/
 	enyo.kind(
 		/** @lends enyo.LeftRightArranger.prototype */ {
+		/**
+			_enyo.LeftRightArranger_ is an [enyo.Arranger](#enyo.Arranger) that displays
+			the active control and some of the previous and next controls. The active
+			control is centered horizontally in the container, and the previous and next
+			controls are laid out to the left and right, respectively.
+
+			Transitions between arrangements are handled by sliding the new control in
+			from the right and sliding the active control out to the left.
+
+			For more information, see the documentation on
+			[Arrangers](building-apps/layout/arrangers.html) in the Enyo Developer Guide.
+		*/
 
 		/**
 		* @private

--- a/panels/source/arrangers/OtherArrangers.js
+++ b/panels/source/arrangers/OtherArrangers.js
@@ -115,8 +115,8 @@
 				var f = this.container.toIndex;
 				var c$ = this.getOrderedControls(f);
 				var o = Math.floor(c$.length/2);
-				var wf = !(s == (c$.length-1) && f === 0) && (s === 0 && f == (c$.length-1));
-		        var wb = (s == (c$.length-1) && f === 0) && !(s === 0 && f == (c$.length-1));
+				var wf = (s === 0 && f == (c$.length-1));
+				var wb = (s == (c$.length-1) && f === 0);
 		        var w = !wb ? wf ? wf : s > f : !wb;
 
 				for (var i=0, c; (c=c$[i]); i++) {

--- a/panels/source/arrangers/OtherArrangers.js
+++ b/panels/source/arrangers/OtherArrangers.js
@@ -115,10 +115,12 @@
 				var f = this.container.toIndex;
 				var c$ = this.getOrderedControls(f);
 				var o = Math.floor(c$.length/2);
-				var w = !(s == (c$.length-1) && f == 0) || (s == 0 && f == (c$.length-1));
+				var wf = !(s == (c$.length-1) && f === 0) && (s === 0 && f == (c$.length-1));
+		        var wb = (s == (c$.length-1) && f === 0) && !(s === 0 && f == (c$.length-1));
+		        var w = !wb ? wf ? wf : s > f : !wb;
 
 				for (var i=0, c; (c=c$[i]); i++) {
-					if (s > f & w){
+					if (w){
 						if (i == (c$.length - o)){
 							c.applyStyle('z-index', 0);
 						} else {


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Derek Anderson <toxigenicpoem@gmail.com>

the current left and right arranger gets direction handling mixed up when index values change from Finish to End, and End to Finish. 

Added variable 'w' which will check to see if the rotator is 'wrapping' during arrangement.