### PR TITLE
BHV-8206: Remove reference to GridFlyWeightRepeater

### DIFF
--- a/layout.design
+++ b/layout.design
@@ -135,13 +135,6 @@
                     }
                 },
                 {
-                    "name": "GridFlyWeightRepeater",
-                    "description": "A grid flyweight repeater",
-                    "config": {
-                        "kind": "enyo.GridFlyWeightRepeater"
-                    }
-                },
-                {
                     "name": "GridListImageItem",
                     "description": "A gridlist image item",
                     "config": {


### PR DESCRIPTION
## Issue

The `enyo.GridFlyWeightRepeater` kind has been deprecated.
## Fix

Remove reference to this deprecated kind.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
