### PR TITLE
[ENYO-265] fixing reordering

### DIFF
--- a/list/samples/ListLanguagesSample.html
+++ b/list/samples/ListLanguagesSample.html
@@ -9,7 +9,7 @@
 	<meta name="google" value="notranslate"/>
 	<title>Languages List Sample</title>
 	<!-- -->
-	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
+	<script src="../../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../../layout/package.js" type="text/javascript"></script>
 	<script src="../../../onyx/package.js" type="text/javascript"></script>
 	<!-- -->


### PR DESCRIPTION
The original code verified the inSender was the current scroll strategy. inSender is unreliable, and event bubbling changes -- changed what the inSender of this event is; this broke reordering. 

The new code is checking that the event's originator, is not the scroll strategy (most likely an item) , and then will engage reordering. 

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
