### PR TITLE
ENYO-369: Use last, non-zero swipe direction when determining swipe completion state.

### DIFF
--- a/list/source/List.js
+++ b/list/source/List.js
@@ -2322,6 +2322,10 @@
 			// save dragged distance (for dragfinish)
 			this.draggedXDistance = event.dx;
 			this.draggedYDistance = event.dy;
+			// save last meaningful (non-zero) and new direction (for swipeDragFinish)
+			if (event.xDirection != this.lastSwipeDirection && event.xDirection) {
+				this.lastSwipeDirection = event.xDirection;
+			}
 			return true;
 		},
 
@@ -2341,7 +2345,7 @@
 			// otherwise if user dragged more than 20% of the width, complete the swipe. if not, back out.
 			} else {
 				var percentageDragged = this.calcPercentageDragged(this.draggedXDistance);
-				if ((percentageDragged > this.percentageDraggedThreshold) && (event.xDirection === this.swipeDirection)) {
+				if ((percentageDragged > this.percentageDraggedThreshold) && (this.lastSwipeDirection === this.swipeDirection)) {
 					this.swipe(this.fastSwipeSpeedMS);
 				} else {
 					this.backOutSwipe(event);


### PR DESCRIPTION
### Issue

When swiping a list item, there can be a gap between the mouse position and the left edge of the swipeable item. This results in the `dx` not changing when reaching the edge of the screen, which sets the `xDirection` value to `0`, and prevents the swipe from completing.
### Fix

We store the last, non-zero swipe direction and use this value for comparison when determining whether or not to complete the swipe.
### Notes

This also needs to be cherry-picked into the `2.5.1-release` branch.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
