### PR TITLE
Fixes ENYO-816

### DIFF
--- a/list/source/FlyweightRepeater.js
+++ b/list/source/FlyweightRepeater.js
@@ -177,6 +177,17 @@
 		},
 
 		/**
+		* Setting cachePoint: true ensures that events from the repeater's subtree will
+		* always bubble up through the repeater, allowing the events to be decorated with repeater-
+		* related metadata and references.
+		*
+		* @type {Boolean}
+		* @default true
+		* @private
+		*/
+		cachePoint: true,
+
+		/**
 		* Design-time attribute indicating whether row indices run
 		* from `0` to [`count`]{@link enyo.FlyweightRepeater#count}`-1` `(false)` or
 		* from [`count`]{@link enyo.FlyweightRepeater#count}`-1` to `0` `(true)`.


### PR DESCRIPTION
## Issue
The event needs to pass through FlyweightRepeater because it decorates the event with the index but, since it doesn't have a handler for the event it isn't registered as a target. So, it works the first time because the bubble cache hasn't been initialized but once it has, it gets skipped.

## Fix
Add cachePoint: true to FlyweightRepeater

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)