### PR TITLE
ENYO-906: Set the correct indices for the onTransitionFinish event.

### DIFF
--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -359,7 +359,7 @@
 		/**
 		* Sets the active panel to the panel specified by the given index.
 		* The transition to the next panel will be immediate and will not be animated,
-		* regardless of the value of the [animate]{@link enyo.Panels#animate} property. 
+		* regardless of the value of the [animate]{@link enyo.Panels#animate} property.
 		*
 		* @param {Number} index - The index of the panel to activate.
 		* @public
@@ -484,7 +484,7 @@
 		* @private
 		*/
 		completed: function () {
-			this.finishTransition(true);
+			this.finishTransition();
 
 			// Animator.onEnd fires asynchronously so we need an internal flag to indicate we need
 			// to start the next transition when the previous completes
@@ -623,7 +623,7 @@
 			this.setupTransition();
 			this.fraction = 1;
 			this.stepTransition();
-			this.teardownTransition();
+			this.completeTransition();
 		},
 
 		/**
@@ -682,22 +682,28 @@
 		*
 		* @private
 		*/
-		finishTransition: function (animating) {
-			this.teardownTransition();
-			this.fireTransitionFinish(animating);
-
+		finishTransition: function () {
+			this.completeTransition(true);
 			this.transitioning = false;
 		},
 
 		/**
-		* Resets transition state
+		* Completes the transition by performing any tasks to be run when the transition ends,
+		* including firing events and clean-up.
 		*
+		* @param {Boolean} [fire] - If `true`, will fire the {@link enyo.Panels#onTransitionFinish}
+		*	event if deemed necessary.
 		* @private
 		*/
-		teardownTransition: function () {
+		completeTransition: function (fire) {
 			if (this.layout) {
 				this.layout.finish();
 			}
+
+			if (fire) {
+				this.fireTransitionFinish();
+			}
+
 			this.transitionPoints = [];
 			this.fraction = 0;
 			this.fromIndex = this.toIndex = null;
@@ -719,10 +725,10 @@
 		* @fires enyo.Panels#onTransitionFinish
 		* @private
 		*/
-		fireTransitionFinish: function (animating) {
+		fireTransitionFinish: function () {
 			var t = this.finishTransitionInfo;
 			if (this.hasNode() && (!t || (t.fromIndex != this.fromIndex || t.toIndex != this.toIndex))) {
-				if (t && animating) {
+				if (this.transitionOnComplete) {
 					this.finishTransitionInfo = {fromIndex: t.toIndex, toIndex: this.lastIndex};
 				} else {
 					this.finishTransitionInfo = {fromIndex: this.lastIndex, toIndex: this.index};


### PR DESCRIPTION
### Issue
The incorrect `toIndex` and `fromIndex` values were being set for the `onTransitionFinish` event. This was due to the fact that a different code path was being taken after some panels refactoring, specifically for the case where an active transition was cut short by the index changing before the transition had completed. The change had caused the code for this case to be run for all index changes for an animated set of panels, which resulted in incorrect indices being set as different index values are necessarily used for this case (as we are in the middle of a to-be-completed transition and new values for the indices have already been set, which cause the transition interruption).

### Fix
We change the conditional to only handle the case where our transition has been interrupted. Additionally, there was an issue where we would be firing the `onTransitionFinish` event regardless of the new indices because  `this.fromIndex` and `this.toIndex` were always null at this point (due to the call to `tearDownTransition` *before* `fireTransitionFinish`). This has been refactored such that the clean-up of the transition state occurs after `fireTransitionFinish` is called.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>