### PR TITLE
ENYO-890: Prevent running animation when no panel arrangement is needed.

### DIFF
--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -450,7 +450,7 @@
 		indexChanged: function (old) {
 			this.lastIndex = old;
 			if (!this.dragging && this.$.animator && this.hasNode()) {
-				if (this.animate) {
+				if (this.shouldAnimate()) {
 					// If we're mid-transition, complete it and indicate we need to transition
 					if (this.$.animator.isAnimating()) {
 						this.transitionOnComplete = true;
@@ -462,6 +462,16 @@
 					this.directTransition();
 				}
 			}
+		},
+
+		/**
+		* Returns `true` if the panels should animate in the transition from `fromIndex` to
+		* `toIndex`.
+		*
+		* @private
+		*/
+		shouldAnimate: function () {
+			return this.animate;
 		},
 
 		/**

--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -466,9 +466,9 @@
 
 		/**
 		* Returns `true` if the panels should animate in the transition from `fromIndex` to
-		* `toIndex`.
+		* `toIndex`. This can be overridden in a {@glossary subkind} for greater customization.
 		*
-		* @private
+		* @protected
 		*/
 		shouldAnimate: function () {
 			return this.animate;


### PR DESCRIPTION
### Issue
There was a delay when moving between panels that did not require a layout arrangement.

### Fix
We ensure that we only execute the extensive animation cycle (involving `enyo.Animator`) when an arrangement is required.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>