### PR TITLE
ENYO-1097: Assign initialize value to this.finishTransitionInfo

### DIFF
--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -736,7 +736,7 @@
 		* @private
 		*/
 		fireTransitionFinish: function () {
-			var t = this.finishTransitionInfo;
+			var t = this.finishTransitionInfo || {fromIndex: null, toIndex: null};
 			if (this.hasNode() && (!t || (t.fromIndex != this.fromIndex || t.toIndex != this.toIndex))) {
 				if (this.transitionOnComplete) {
 					this.finishTransitionInfo = {fromIndex: t.toIndex, toIndex: this.lastIndex};

--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -736,10 +736,12 @@
 		* @private
 		*/
 		fireTransitionFinish: function () {
-			var t = this.finishTransitionInfo || {fromIndex: null, toIndex: null};
-			if (this.hasNode() && (!t || (t.fromIndex != this.fromIndex || t.toIndex != this.toIndex))) {
+			var t = this.finishTransitionInfo,
+				fromIndex = t ? t.fromIndex : null,
+				toIndex = t ? t.toIndex : null;
+			if (this.hasNode() && (!t || (fromIndex != this.fromIndex || toIndex != this.toIndex))) {
 				if (this.transitionOnComplete) {
-					this.finishTransitionInfo = {fromIndex: t.toIndex, toIndex: this.lastIndex};
+					this.finishTransitionInfo = {fromIndex: toIndex, toIndex: this.lastIndex};
 				} else {
 					this.finishTransitionInfo = {fromIndex: this.lastIndex, toIndex: this.index};
 				}


### PR DESCRIPTION
### Issue:
The fireTransitionFinish is reference self assigned variable 'this.finishTransitionInfo' when it is revisited with transitionOnComplete set as true. In this case, it throw error like t is undefined in 't.toIndex'.

### Fix:
Assign initial value into finishTransitionInfo if it is undefined to avoid initial self reference problem.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com