### PR TITLE
Fixes ENYO-1113

### DIFF
--- a/list/samples/ListPulldownSample.js
+++ b/list/samples/ListPulldownSample.js
@@ -68,7 +68,7 @@ enyo.kind({
 		}
 	},
 	processAjaxSearchResults: function(inRequest, inResponse) {
-		inResponse = JSON.parse(inResponse);
+		inResponse = enyo.json.parse(inResponse);
 		this.processSearchResults(inRequest, inResponse);
 	},
 	processSearchResults: function(inRequest, inResponse) {

--- a/panels/samples/PanelsFlickrSample.js
+++ b/panels/samples/PanelsFlickrSample.js
@@ -154,7 +154,7 @@ enyo.kind({
 		return req;
 	},
 	processAjaxResponse: function(inSender, inResponse) {
-		inResponse = JSON.parse(inResponse);
+		inResponse = enyo.json.parse(inResponse);
 		this.processResponse(inSender, inResponse);
 	},
 	processResponse: function(inSender, inResponse) {


### PR DESCRIPTION
## Issue
Using the native JSON object fails linting for es3 because it isn't defined in that version

## Fix
Use the enyo wrapper (enyo.json) instead

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)