### PR TITLE
ENYO-510 - Added placeholder as published property in GridListImageItem

### DIFF
--- a/list/source/GridListImageItem.css
+++ b/list/source/GridListImageItem.css
@@ -11,8 +11,7 @@
 	display: block;
 	width: 100%;
 	height: 100%;
-	background-size: 100% 100%;
-	background-repeat: no-repeat;
+	max-height: 100%;
 }
 .enyo-gridlist-imageitem >.caption,
 .enyo-gridlist-imageitem >.sub-caption {

--- a/list/source/GridListImageItem.css
+++ b/list/source/GridListImageItem.css
@@ -11,9 +11,8 @@
 	display: block;
 	width: 100%;
 	height: 100%;
+	background-size: 100% 100%;
 	background-repeat: no-repeat;
-	background-position: center center;
-	background-size: cover;
 }
 .enyo-gridlist-imageitem >.caption,
 .enyo-gridlist-imageitem >.sub-caption {

--- a/list/source/GridListImageItem.css
+++ b/list/source/GridListImageItem.css
@@ -10,6 +10,10 @@
 .enyo-gridlist-imageitem img {
 	display: block;
 	width: 100%;
+	height: 100%;
+	background-repeat: no-repeat;
+	background-position: center center;
+	background-size: cover;
 }
 .enyo-gridlist-imageitem >.caption,
 .enyo-gridlist-imageitem >.sub-caption {
@@ -53,4 +57,7 @@
 .enyo-gridlist-imageitem.sized-image > .sub-caption {
 	position: absolute;
 	bottom: 0;
+}
+.enyo-gridlist-imageitem:not(.sized-image){
+	padding-bottom: 3.5rem;
 }

--- a/list/source/GridListImageItem.js
+++ b/list/source/GridListImageItem.js
@@ -122,7 +122,14 @@
 			* @default true
 			* @public
 			*/
-			useSubCaption: true
+			useSubCaption: true,
+
+			/**
+			* @type {String}
+			* @default ''
+			* @public
+			*/
+			placeholder: ''
 		},
 
 		/**
@@ -133,7 +140,8 @@
 			{from: '.caption', to: '.$.caption.content'},
 			{from: '.caption', to: '.$.caption.showing', kind: 'enyo.EmptyBinding'},
 			{from: '.subCaption', to: '.$.subCaption.content'},
-			{from: '.subCaption', to: '.$.subCaption.showing', kind: 'enyo.EmptyBinding'}
+			{from: '.subCaption', to: '.$.subCaption.showing', kind: 'enyo.EmptyBinding'},
+			{from: '.placeholder', to: '.$.image.placeholder'}
 		],
 
 		/**

--- a/list/source/GridListImageItem.js
+++ b/list/source/GridListImageItem.js
@@ -136,12 +136,12 @@
 		* @private
 		*/
 		bindings: [
-			{from: '.source', to: '.$.image.src'},
-			{from: '.caption', to: '.$.caption.content'},
-			{from: '.caption', to: '.$.caption.showing', kind: 'enyo.EmptyBinding'},
-			{from: '.subCaption', to: '.$.subCaption.content'},
-			{from: '.subCaption', to: '.$.subCaption.showing', kind: 'enyo.EmptyBinding'},
-			{from: '.placeholder', to: '.$.image.placeholder'}
+			{from: 'source', to: '$.image.src'},
+			{from: 'caption', to: '$.caption.content'},
+			{from: 'caption', to: '$.caption.showing', kind: 'enyo.EmptyBinding'},
+			{from: 'subCaption', to: '$.subCaption.content'},
+			{from: 'subCaption', to: '$.subCaption.showing', kind: 'enyo.EmptyBinding'},
+			{from: 'placeholder', to: '$.image.placeholder'}
 		],
 
 		/**

--- a/list/source/GridListImageItem.js
+++ b/list/source/GridListImageItem.js
@@ -162,12 +162,8 @@
 		* @private
 		*/
 		placeholderChanged: function(){
-			var placeholder= enyo.path.rewrite(this.placeholder);
-			//for img tag
-			if (!this.imageSizing) {
-				//remove previously set default background
-				this.$.image.applyStyle('background-image','');
-				this.$.image.applyStyle('background-image', "url('"+(placeholder ? placeholder : enyo.Image.placeholder)+"')" );
+			if(this.imageSizing){
+				this.placeholder= this.placeholder? this.placeholder : enyo.Image.placeholder; 
 			}
 		},
 

--- a/list/source/GridListImageItem.js
+++ b/list/source/GridListImageItem.js
@@ -154,8 +154,22 @@
 				this.selectedChanged();
 				this.imageSizingChanged();
 				this.centeredChanged();
+				this.placeholderChanged();
 			};
 		}),
+
+		/**
+		* @private
+		*/
+		placeholderChanged: function(){
+			var placeholder= enyo.path.rewrite(this.placeholder);
+			//for img tag
+			if (!this.imageSizing) {
+				//remove previously set default background
+				this.$.image.applyStyle('background-image','');
+				this.$.image.applyStyle('background-image', "url('"+(placeholder ? placeholder : enyo.Image.placeholder)+"')" );
+			}
+		},
 
 		/**
 		* @private

--- a/list/source/GridListImageItem.js
+++ b/list/source/GridListImageItem.js
@@ -154,18 +154,8 @@
 				this.selectedChanged();
 				this.imageSizingChanged();
 				this.centeredChanged();
-				this.placeholderChanged();
 			};
 		}),
-
-		/**
-		* @private
-		*/
-		placeholderChanged: function(){
-			if(this.imageSizing){
-				this.placeholder= this.placeholder? this.placeholder : enyo.Image.placeholder; 
-			}
-		},
 
 		/**
 		* @private


### PR DESCRIPTION
Issue:

Application developer needs to pass some placeholder image, which will be shown until the dynamic image gets loaded.

Fix:

Created a published property named as placeholder and binded so as to pass it to Image kind. Also, CSS changes done to apply required padding so to accomodate caption & sub-caption in case of img tag.

Enyo-DCO-1.1-Signed-off-by: Rakesh kumar rakesh25.kumar@lge.com