### PR TITLE
ENYO-1168 Make transitioning false to mark transition is not going on.

### DIFF
--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -633,6 +633,7 @@
 			this.setupTransition();
 			this.fraction = 1;
 			this.stepTransition();
+			this.transitioning = false;
 			this.completeTransition();
 		},
 
@@ -858,7 +859,7 @@
 			* @param  {Object[]} a1     - Array of target arrangement object.
 			* @param  {Number} fraction - The fraction (between 0 and 1) with which to lerp.
 			* @return {Object[]}        - Array of arrangements that is `fraction` between
-			* 	`a0` and `a1`.
+			*	`a0` and `a1`.
 			* @private
 			*/
 			lerp: function (a0, a1, fraction) {


### PR DESCRIPTION
Rebased the changes from #125 to remove unnecessary commits.

Issue
-------
When user calls resize() during panels transition, animation is terminated without proper complete.

Cause
--------
Panels transition requires to modify div using enyo.dom.transform().
However, resize() will reflow current page again so previous work is halted.

Fix
-----
Force to complete transition animation in this case.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com