### PR TITLE
ENYO-1168 Make transitioning false to mark transition is not going on.

### DIFF
--- a/panels/source/Panels.js
+++ b/panels/source/Panels.js
@@ -633,6 +633,7 @@
 			this.setupTransition();
 			this.fraction = 1;
 			this.stepTransition();
+			this.transitioning = false;
 			this.completeTransition();
 		},
 
@@ -842,7 +843,7 @@
 			* @param  {Object[]} a1     - Array of target arrangement object.
 			* @param  {Number} fraction - The fraction (between 0 and 1) with which to lerp.
 			* @return {Object[]}        - Array of arrangements that is `fraction` between
-			* 	`a0` and `a1`.
+			*	`a0` and `a1`.
 			* @private
 			*/
 			lerp: function (a0, a1, fraction) {


### PR DESCRIPTION
This property is used to notify there is a transition in progress.
But calling refresh() should stop(or complete) panel transition, so we'd better make it false.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com

Originally merged into master from https://github.com/enyojs/layout/pull/128.