### PR TITLE
ENYO-510 : Added placeholder as published property in GridListImageItem

### DIFF
--- a/lib/GridListImageItem/GridListImageItem.css
+++ b/lib/GridListImageItem/GridListImageItem.css
@@ -10,6 +10,8 @@
 .enyo-gridlist-imageitem img {
 	display: block;
 	width: 100%;
+	height: 100%;
+	max-height: 100%;
 }
 .enyo-gridlist-imageitem >.caption,
 .enyo-gridlist-imageitem >.sub-caption {
@@ -53,4 +55,7 @@
 .enyo-gridlist-imageitem.sized-image > .sub-caption {
 	position: absolute;
 	bottom: 0;
+}
+.enyo-gridlist-imageitem:not(.sized-image){
+	padding-bottom: 3.5rem;
 }

--- a/lib/GridListImageItem/GridListImageItem.js
+++ b/lib/GridListImageItem/GridListImageItem.js
@@ -96,7 +96,7 @@ module.exports = kind(
 		/**
 		* By default, the width of the image fits the width of the item, and the
 		* height is sized naturally, based on the image's aspect ratio. Set this
-		* property to `'constrain'` to letterbox the image in the available space,
+		* property to `'contain'` to letterbox the image in the available space,
 		* or `'cover'` to cover the available space with the image (cropping the
 		* larger dimension). Note that when `imageSizing` is explicitly specified,
 		* you must indicate whether the caption and subcaption are used (by setting
@@ -132,18 +132,29 @@ module.exports = kind(
 		* @default true
 		* @public
 		*/
-		useSubCaption: true
+		useSubCaption: true,
+
+		/**
+		* Placeholder image used while {@link enyo.GridListImageItem#source} is loaded
+		*
+		* @see enyo.Image#placeholder
+		* @type {String}
+		* @default ''
+		* @public
+		*/
+		placeholder: ''
 	},
 
 	/**
 	* @private
 	*/
 	bindings: [
-		{from: '.source', to: '.$.image.src'},
-		{from: '.caption', to: '.$.caption.content'},
-		{from: '.caption', to: '.$.caption.showing', kind: EmptyBinding},
-		{from: '.subCaption', to: '.$.subCaption.content'},
-		{from: '.subCaption', to: '.$.subCaption.showing', kind: EmptyBinding}
+		{from: 'source', to: '$.image.src'},
+		{from: 'caption', to: '$.caption.content'},
+		{from: 'caption', to: '$.caption.showing', kind: EmptyBinding},
+		{from: 'subCaption', to: '$.subCaption.content'},
+		{from: 'subCaption', to: '$.subCaption.showing', kind: EmptyBinding},
+		{from: 'placeholder', to: '$.image.placeholder'}
 	],
 
 	/**


### PR DESCRIPTION
Issue:

There was no placeholder in image grid, and image gets displayed once loaded. In between grid remains empty.

Fix:

Using multiple background images through css, we can set the placeholder, a static image, which will be seen until the image gets loaded and will be replaced.

Enyo-DCO-1.1-Signed-off-by: Rakesh kumar rakesh25.kumar@lge.com