### PR TITLE
support swipeable in a pulldown list

### DIFF
--- a/list/source/PulldownList.js
+++ b/list/source/PulldownList.js
@@ -306,6 +306,11 @@
 				s.setScrollY(-1*this.getScrollTop() - this.pullHeight);
 				this.pullRelease();
 			}
+			else {
+				// if base list is configured for swipe, ensure 
+				// has a chance to process swipe
+				this.inherited(arguments);
+			}
 		},
 
 		/**


### PR DESCRIPTION
I have been using a PulldownList and also wanted the swipable config to function. I tracked down the problem to the PulldownList essentially swallowing events required for Pulldown functionality. It turns out some events should be passed to the "base" class in case they need to process the events as well (such as for swipable processing).

It would be nice if this could be incorporated into Enyo so I could continue to update to later versions of Enyo.
Enyo-DCO-1.1-Signed-off-by: Michael Persons <michael.jp.persons@gmail.com>