### PR TITLE
ENYO-2313: Display placeholder image whenever specified.

### DIFF
--- a/lib/GridListImageItem/GridListImageItem.css
+++ b/lib/GridListImageItem/GridListImageItem.css
@@ -14,6 +14,11 @@
 	height: 100%;
 	max-height: 100%;
 }
+// The intended effect is for the image in a GridListImageItem context to have 100% width and height
+.enyo-gridlist-imageitem > .image {
+	width: 100%;
+	height: 100%;
+}
 .enyo-gridlist-imageitem >.caption,
 .enyo-gridlist-imageitem >.sub-caption {
 	font-size: 10pt;
@@ -40,10 +45,6 @@
 .enyo-gridlist-imageitem.sized-image.use-caption,
 .enyo-gridlist-imageitem.sized-image.use-subcaption {
 	padding-bottom: 25px;
-}
-.enyo-gridlist-imageitem.sized-image > .image {
-	width: 100%;
-	height: 100%;
 }
 .enyo-gridlist-imageitem.sized-image.use-caption.use-subcaption > .caption {
 	position: absolute;


### PR DESCRIPTION
### Issue
The placeholder image in a `GridListImageItem` was not visible in the case where we were not displaying the image as a background-image.

### Fix
It appears that the intended effect for a `GridListImageItem` is to display the image at 100% width and height. Thus, we do not need to differentiate between the cases where we are and are not displaying the image as a background-image, and using or not using a placeholder image. Instead, we have set the child image element to always have 100% width and height. This is necessary because of an `img` element loading issue where 100% height results in a height of 0, before the image has loaded.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>