### PR TITLE
ENYO-2418: fix recursion with defaultKind

### DIFF
--- a/src/Node/Node.js
+++ b/src/Node/Node.js
@@ -87,11 +87,6 @@ var TreeNode = module.exports = kind(
 	name: 'enyo.Node',
 
 	/**
-	* @private
-	*/
-	kind: Control,
-
-	/**
 	* @lends module:layout/Node~Node.prototype
 	* @private
 	*/
@@ -155,8 +150,10 @@ var TreeNode = module.exports = kind(
 
 	/**
 	* @private
+	*
+	* set during `create`
 	*/
-	defaultKind: TreeNode,
+	defaultKind: '',
 
 	/**
 	* @private
@@ -204,6 +201,7 @@ var TreeNode = module.exports = kind(
 	*/
 	create: kind.inherit(function (sup) {
 		return function () {
+			this.defaultKind = TreeNode;
 			sup.apply(this, arguments);
 			//this.expandedChanged();
 			//this.levelChanged();


### PR DESCRIPTION
Issue.

TreeNode places all nodes on the same level, because the reference to defaultKind isn't the ctor for the TreeNode kind (hasn't been returned yet);

Fix.

Set the defaultKind in the `create` method of the control.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
