### PR TITLE
ENYO-2258--ListActions: Scroller in list action is not showed

### DIFF
--- a/src/FittableLayout/FittableLayout.js
+++ b/src/FittableLayout/FittableLayout.js
@@ -96,7 +96,7 @@ var FittableLayout = module.exports = kind(/** @lends module:layout/FittableLayo
 	* @private
 	*/
 	_reflowOnShowing: function (was, is, prop) {
-		if (is) {
+		if (is && this._hiddenReflow) {
 			this.reflow();
 		}
 	},
@@ -249,6 +249,14 @@ var FittableLayout = module.exports = kind(/** @lends module:layout/FittableLayo
 
 		nFitSize = nTotalSize - (nBeforeOffset + nAfterOffset);
 		oFitChild.applyStyle(sMeasureName, nFitSize + 'px');
+
+		// check if it reflows while container is showing and fit child has a valid height
+		// then remember the state
+		if (this.container.showing && nFitSize > 0) {
+			this._hiddenReflow = false;
+		} else {
+			this._hiddenReflow = true;
+		}
 	},
 
 	/**

--- a/src/FittableLayout/FittableLayout.js
+++ b/src/FittableLayout/FittableLayout.js
@@ -96,9 +96,8 @@ var FittableLayout = module.exports = kind(/** @lends module:layout/FittableLayo
 	* @private
 	*/
 	_reflowOnShowing: function (was, is, prop) {
-		if (is && this._hiddenReflow) {
+		if (is) {
 			this.reflow();
-			this._hiddenReflow = false;
 		}
 	},
 
@@ -199,9 +198,6 @@ var FittableLayout = module.exports = kind(/** @lends module:layout/FittableLayo
 	*/
 	_reflow: function(sMeasureName, sClienMeasure, sAttrBefore, sAttrAfter) {
 		this.container.addRemoveClass('enyo-stretch', !this.container.noStretch);
-		
-		// check if it overflows while container is not showing and remember the state
-		if (!this.container.showing) this._hiddenReflow = true;
 
 		var oFitChild       = this.getFitControl(),
 			oContainerNode  = this.container.hasNode(),  // Container node


### PR DESCRIPTION
Issue: Scroller is '0' height as its parent is reflowed while its in
hidden state
Fix: Whenever the showing status of a layout is changed from hidden to show, the layout is
reflown.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P <rajyavardhan.p@lge.com>