### PR TITLE
ENYO-1724: Subtract container padding from fit control width of Fitta…

### DIFF
--- a/src/FittableLayout/FittableLayout.js
+++ b/src/FittableLayout/FittableLayout.js
@@ -230,7 +230,7 @@ var FittableLayout = module.exports = kind(/** @lends module:layout/FittableLayo
 				nBeforeOffset = nMarginBeforeFirstChild;
 			} else {
 				var oFirstChildBounds      = oFirstChild.getBounds(),
-					nSpaceBeforeFirstChild = oFirstChildBounds[sAttrBefore];
+					nSpaceBeforeFirstChild = oFirstChildBounds[sAttrBefore] - (oPadding[sAttrBefore] || 0);
 
 				nBeforeOffset = oBounds[sAttrBefore] + nMarginBeforeFirstChild - nSpaceBeforeFirstChild;
 			}


### PR DESCRIPTION
…ble in RTL locale

Issue:
- In RTL locale, fit control width is larget than expected when
  container has padding.
- Because, fittable is not consider container padding in RTL locale.

Fix:
- Now we consider container padding in RTL locale just like LTR.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>