### PR TITLE
ENYO-2743 Calculate proper index only from panels not from every clie…

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -261,7 +261,7 @@ var Panels = module.exports = kind(
 			// adjust index if the current panel is being removed
 			// so it's either the previous panel or the first one.
 			var newIndex = -1;
-			var controlIndex = utils.indexOf(control, this.controls);
+			var controlIndex = utils.indexOf(control, this.getPanels());
 			if (controlIndex === this.index) {
 				newIndex = Math.max(controlIndex - 1, 0);
 			}


### PR DESCRIPTION
…nt controls
## Issue

Currently {{controlIndex}} is calculated from every client controls in panels.
But purpose of controlIndex is, returning active index from panels.
## Cause

We should find an index only from set of panel. Not from client controls
## Fix

Fix index calculation logic

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
