### PR TITLE
ENYO-2985: Fix the defaultKind.

### DIFF
--- a/src/Node/Node.js
+++ b/src/Node/Node.js
@@ -160,7 +160,7 @@ var TreeNode = module.exports = kind(
 	/**
 	* @private
 	*/
-	defaultKind: TreeNode,
+	defaultKind: null, // set after the fact
 
 	/**
 	* @private
@@ -429,3 +429,5 @@ var TreeNode = module.exports = kind(
 		//this.contentChanged();
 	}
 });
+
+TreeNode.prototype.defaultKind = TreeNode;


### PR DESCRIPTION
### Issue
The `defaultKind` of `layout/Node` is not properly set as it is self-referential. Children of `layout/Node` become `enyo/Control` kinds instead of `layout/Node` kinds, when the kind is not explicitly specified.

### Fix
We use the pattern found in `enyo/Control` to set the `defaultKind` after the kind has been created.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>