### PR TITLE
ENYO-650: Tweak panel transitions

### DIFF
--- a/src/Arranger/Arranger.js
+++ b/src/Arranger/Arranger.js
@@ -372,7 +372,7 @@ Arranger.positionControl = function (control, bounds, unit) {
 	unit = unit || 'px';
 	if (!this.updating) {
 		// IE10 uses setBounds because of control hit caching problems seem in some apps
-		if (Dom.canTransform() && !control.preventTransform && !platform.android && platform.ie !== 10) {
+		if (Dom.canTransform() && !control.preventTransform && platform.ie !== 10) {
 			var l = bounds.left, t = bounds.top;
 			l = utils.isString(l) ? l : l && (l + unit);
 			t = utils.isString(t) ? t : t && (t + unit);

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -502,6 +502,7 @@ var Panels = module.exports = kind(
 	*/
 	animationEnded: function (sender, event) {
 		this.completed();
+		return true;
 	},
 
 	/**
@@ -651,6 +652,7 @@ var Panels = module.exports = kind(
 		this.stepTransition();
 		this.transitioning = false;
 		this.completeTransition();
+		this.dragging = false;
 	},
 
 	/**

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -540,6 +540,7 @@ var Panels = module.exports = kind(
 		if (this.dragging) {
 			event.preventDefault();
 			this.dragTransition(event);
+			return true;
 		}
 	},
 
@@ -551,6 +552,7 @@ var Panels = module.exports = kind(
 			this.dragging = false;
 			event.preventTap();
 			this.dragfinishTransition(event);
+			return true;
 		}
 	},
 


### PR DESCRIPTION
### Issue
These are primarily changes from https://github.com/enyojs/layout/pull/107. We had previously been guarding against acceleration panel transitions on Android, but this was a heavy-handed approach to take.

### Fix
The guard was removed as the original behavior did not present itself on Android. Additionally, we prevent unnecessary or undesired propagation of `drag` and `dragfinish` if we are currently handling a drag in the panels instance.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>