### PR TITLE
ENYO-3222: Use updated cancelAnimationFrame API.

### DIFF
--- a/src/List/methods.js
+++ b/src/List/methods.js
@@ -2076,7 +2076,7 @@ module.exports = /** @lends module:layout/List~List.prototype */ {
 	*/
 	stopAnimateSwipe: function () {
 		if (this.job) {
-			this.job = animation.cancelRequestAnimationFrame(this.job);
+			this.job = animation.cancelAnimationFrame(this.job);
 		}
 	}
 };


### PR DESCRIPTION
### Issue
Due to the changes in https://github.com/enyojs/enyo/pull/1414, the API being used has been deprecated.

### Fix
Updated to use `cancelAnimationFrame`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>